### PR TITLE
refactor the querying functions into their own module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ language: elixir
 otp_release:
  - 17.4
 elixir:
- - 1.0
+ - 1.0.2
+ - 1.0.3
+ - 1.0.4
 after_script:
   - MIX_ENV=dev mix deps.get
   - MIX_ENV=dev mix inch.report

--- a/lib/sqlitex.ex
+++ b/lib/sqlitex.ex
@@ -1,6 +1,4 @@
 defmodule Sqlitex do
-  alias Sqlitex.Query, as: Q
-
   def close(db) do
     :esqlite3.close(db)
   end
@@ -21,12 +19,7 @@ defmodule Sqlitex do
     :esqlite3.exec(sql, db)
   end
 
-  def query(db, sql, opts \\ []) do
-    Q.prepare(sql, db)
-      |> Q.bind_values(opts)
-      |> Q.execute(opts)
-      |> Q.to_rows
-  end
+  def query(db, sql, opts \\ []), do: Sqlitex.Query.query(db, sql, opts)
 
   @doc """
   Create a new table `name` where `table_opts` are a list of table constraints

--- a/lib/sqlitex.ex
+++ b/lib/sqlitex.ex
@@ -1,4 +1,6 @@
 defmodule Sqlitex do
+  alias Sqlitex.Query, as: Q
+
   def close(db) do
     :esqlite3.close(db)
   end
@@ -20,10 +22,10 @@ defmodule Sqlitex do
   end
 
   def query(db, sql, opts \\ []) do
-    case :esqlite3.prepare(sql, db) do
-      {:ok, statement} -> bind_and_query(statement, opts)
-      {:error, _}=error -> error
-    end
+    Q.prepare(sql, db)
+      |> Q.bind_values(opts)
+      |> Q.execute(opts)
+      |> Q.to_rows
   end
 
   @doc """
@@ -46,54 +48,5 @@ defmodule Sqlitex do
   def create_table(db, name, table_opts \\ [], cols) do
     stmt = Sqlitex.SqlBuilder.create_table(name, table_opts, cols)
     exec(db, stmt)
-  end
-
-  defp bind_and_query(statement, opts) do
-    {params, into} = query_options(opts)
-    case :esqlite3.bind(statement, params) do
-      {:error, _}=error -> error
-      :ok ->
-        types = :esqlite3.column_types(statement)
-        columns = :esqlite3.column_names(statement)
-        rows = :esqlite3.fetchall(statement)
-        return_rows_or_error(types, columns, rows, into)
-    end
-  end
-
-  defp query_options(opts) do
-    params = opts |> Keyword.get(:bind, []) |> translate_bindings
-    into = Keyword.get(opts, :into, [])
-    {params, into}
-  end
-
-  defp translate_bindings(params) do
-    Enum.map(params, fn
-      nil -> :undefined
-      true -> 1
-      false -> 0
-      datetime={{_yr, _mo, _da}, {_hr, _mi, _se, _usecs}} -> datetime_to_string(datetime)
-      other -> other
-    end)
-  end
-
-  # Translate the given Erlang datetime tuple to an appropriate string for
-  # SQLite.  Microseconds are zeroed.
-  defp datetime_to_string({{yr, mo, da}, {hr, mi, se, usecs}}) do
-    [zero_pad(yr, 4), "-", zero_pad(mo, 2), "-", zero_pad(da, 2), " ", zero_pad(hr, 2), ":", zero_pad(mi, 2), ":", zero_pad(se, 2), ".", zero_pad(usecs, 6)]
-    |> Enum.join
-  end
-
-  defp zero_pad(num, len) do
-    str = Integer.to_string num
-    String.duplicate("0", len - String.length(str)) <> str
-  end
-
-  defp return_rows_or_error(_, _, {:error, _} = error, _), do: error
-  defp return_rows_or_error({:error, :no_columns}, columns, rows, into), do: return_rows_or_error({}, columns, rows, into)
-  defp return_rows_or_error({:error, _} = error, _columns, _rows, _into), do: error
-  defp return_rows_or_error(types, {:error, :no_columns}, rows, into), do: return_rows_or_error(types, {}, rows, into)
-  defp return_rows_or_error(_types, {:error, _} = error, _rows, _into), do: error
-  defp return_rows_or_error(types, columns, rows, into) do
-    Sqlitex.Row.from(Tuple.to_list(types), Tuple.to_list(columns), rows, into)
   end
 end

--- a/lib/sqlitex/query.ex
+++ b/lib/sqlitex/query.ex
@@ -11,7 +11,7 @@ defmodule Sqlitex.Query do
             statement: nil
 
   def query(db, sql, opts \\ []) do
-    pipe_matching {:ok, %Sqlitex.Query{}},
+    pipe_matching {:ok, _},
       {:ok, %Sqlitex.Query{bindings: bindings_from_opts(opts), into: into_from_opts(opts), database: db, sql: sql}}
         |> prepare
         |> bind_values

--- a/lib/sqlitex/query.ex
+++ b/lib/sqlitex/query.ex
@@ -1,0 +1,54 @@
+defmodule Sqlitex.Query do
+  def bind_values({:error, _}=error, _opts), do: error
+  def bind_values({:ok, statement}, opts) do
+    params = params_from_opts(opts)
+    case :esqlite3.bind(statement, params) do
+      {:error,_}=error -> error
+      :ok -> {:ok, statement}
+    end
+  end
+
+  def execute({:error,_}=error, _opts), do: {error, {}, {}, []}
+  def execute({:ok, statement}, opts) do
+    into = into_from_opts(opts)
+    types = :esqlite3.column_types(statement)
+    columns = :esqlite3.column_names(statement)
+    data = :esqlite3.fetchall(statement)
+    {types, columns, data, into}
+  end
+
+  def prepare(sql, database), do: :esqlite3.prepare(sql, database)
+
+  def to_rows({_,_,{:error,_}=error,_}), do: error
+  def to_rows({{:error, :no_columns}, columns, rows, into}), do: to_rows({{}, columns, rows, into})
+  def to_rows({{:error, _}=error, _columns, _rows, _into}), do: error
+  def to_rows({types, {:error, :no_columns}, rows, into}), do: to_rows({types, {}, rows, into})
+  def to_rows({_types, {:error, _}=error, _rows, _into}), do: error
+  def to_rows({types, columns, rows, into}) do
+    Sqlitex.Row.from(Tuple.to_list(types), Tuple.to_list(columns), rows, into)
+  end
+
+  defp datetime_to_string({{yr, mo, da}, {hr, mi, se, usecs}}) do
+    [zero_pad(yr, 4), "-", zero_pad(mo, 2), "-", zero_pad(da, 2), " ", zero_pad(hr, 2), ":", zero_pad(mi, 2), ":", zero_pad(se, 2), ".", zero_pad(usecs, 6)]
+    |> Enum.join
+  end
+
+  defp into_from_opts(opts), do: Keyword.get(opts, :into, [])
+
+  defp params_from_opts(opts), do: opts |> Keyword.get(:bind, []) |> translate_bindings
+
+  defp translate_bindings(params) do
+    Enum.map(params, fn
+      nil -> :undefined
+      true -> 1
+      false -> 0
+      datetime={{_yr, _mo, _da}, {_hr, _mi, _se, _usecs}} -> datetime_to_string(datetime)
+      other -> other
+    end)
+  end
+
+  defp zero_pad(num, len) do
+    str = Integer.to_string num
+    String.duplicate("0", len - String.length(str)) <> str
+  end
+end

--- a/lib/sqlitex/query.ex
+++ b/lib/sqlitex/query.ex
@@ -8,7 +8,6 @@ defmodule Sqlitex.Query do
         |> execute(opts)
   end
 
-  defp bind_values({:error, _}=error, _opts), do: error
   defp bind_values({:ok, statement}, opts) do
     params = params_from_opts(opts)
     case :esqlite3.bind(statement, params) do
@@ -22,7 +21,6 @@ defmodule Sqlitex.Query do
     |> Enum.join
   end
 
-  defp execute({:error,_}=error, _opts), do: {error, {}, {}, []}
   defp execute({:ok, statement}, opts) do
     into = into_from_opts(opts)
     types = :esqlite3.column_types(statement)

--- a/lib/sqlitex/query.ex
+++ b/lib/sqlitex/query.ex
@@ -1,6 +1,13 @@
 defmodule Sqlitex.Query do
-  def bind_values({:error, _}=error, _opts), do: error
-  def bind_values({:ok, statement}, opts) do
+  def query(db, sql, opts \\ []) do
+    prepare(sql, db)
+      |> bind_values(opts)
+      |> execute(opts)
+      |> to_rows
+  end
+
+  defp bind_values({:error, _}=error, _opts), do: error
+  defp bind_values({:ok, statement}, opts) do
     params = params_from_opts(opts)
     case :esqlite3.bind(statement, params) do
       {:error,_}=error -> error
@@ -8,8 +15,13 @@ defmodule Sqlitex.Query do
     end
   end
 
-  def execute({:error,_}=error, _opts), do: {error, {}, {}, []}
-  def execute({:ok, statement}, opts) do
+  defp datetime_to_string({{yr, mo, da}, {hr, mi, se, usecs}}) do
+    [zero_pad(yr, 4), "-", zero_pad(mo, 2), "-", zero_pad(da, 2), " ", zero_pad(hr, 2), ":", zero_pad(mi, 2), ":", zero_pad(se, 2), ".", zero_pad(usecs, 6)]
+    |> Enum.join
+  end
+
+  defp execute({:error,_}=error, _opts), do: {error, {}, {}, []}
+  defp execute({:ok, statement}, opts) do
     into = into_from_opts(opts)
     types = :esqlite3.column_types(statement)
     columns = :esqlite3.column_names(statement)
@@ -17,25 +29,20 @@ defmodule Sqlitex.Query do
     {types, columns, data, into}
   end
 
-  def prepare(sql, database), do: :esqlite3.prepare(sql, database)
-
-  def to_rows({_,_,{:error,_}=error,_}), do: error
-  def to_rows({{:error, :no_columns}, columns, rows, into}), do: to_rows({{}, columns, rows, into})
-  def to_rows({{:error, _}=error, _columns, _rows, _into}), do: error
-  def to_rows({types, {:error, :no_columns}, rows, into}), do: to_rows({types, {}, rows, into})
-  def to_rows({_types, {:error, _}=error, _rows, _into}), do: error
-  def to_rows({types, columns, rows, into}) do
-    Sqlitex.Row.from(Tuple.to_list(types), Tuple.to_list(columns), rows, into)
-  end
-
-  defp datetime_to_string({{yr, mo, da}, {hr, mi, se, usecs}}) do
-    [zero_pad(yr, 4), "-", zero_pad(mo, 2), "-", zero_pad(da, 2), " ", zero_pad(hr, 2), ":", zero_pad(mi, 2), ":", zero_pad(se, 2), ".", zero_pad(usecs, 6)]
-    |> Enum.join
-  end
-
   defp into_from_opts(opts), do: Keyword.get(opts, :into, [])
 
   defp params_from_opts(opts), do: opts |> Keyword.get(:bind, []) |> translate_bindings
+
+  defp prepare(sql, database), do: :esqlite3.prepare(sql, database)
+
+  defp to_rows({_,_,{:error,_}=error,_}), do: error
+  defp to_rows({{:error, :no_columns}, columns, rows, into}), do: to_rows({{}, columns, rows, into})
+  defp to_rows({{:error, _}=error, _columns, _rows, _into}), do: error
+  defp to_rows({types, {:error, :no_columns}, rows, into}), do: to_rows({types, {}, rows, into})
+  defp to_rows({_types, {:error, _}=error, _rows, _into}), do: error
+  defp to_rows({types, columns, rows, into}) do
+    Sqlitex.Row.from(Tuple.to_list(types), Tuple.to_list(columns), rows, into)
+  end
 
   defp translate_bindings(params) do
     Enum.map(params, fn

--- a/mix.exs
+++ b/mix.exs
@@ -21,6 +21,7 @@ defmodule Sqlitex.Mixfile do
   defp deps do
     [
       {:esqlite, "~> 0.1.0"},
+      {:pipe, "~> 0.0.1"},
 
       {:earmark, ">= 0.0.0", only: :dev},
       {:ex_doc, "~> 0.7", only: :dev},

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,7 @@ defmodule Sqlitex.Mixfile do
   defp deps do
     [
       {:esqlite, "~> 0.1.0"},
-      {:pipe, "~> 0.0.1"},
+      {:pipe, "~> 0.0.2"},
 
       {:earmark, ">= 0.0.0", only: :dev},
       {:ex_doc, "~> 0.7", only: :dev},

--- a/mix.lock
+++ b/mix.lock
@@ -2,5 +2,5 @@
   "esqlite": {:hex, :esqlite, "0.1.0"},
   "ex_doc": {:hex, :ex_doc, "0.7.2"},
   "inch_ex": {:hex, :inch_ex, "0.2.4"},
-  "pipe": {:hex, :pipe, "0.0.1"},
+  "pipe": {:hex, :pipe, "0.0.2"},
   "poison": {:hex, :poison, "1.4.0"}}

--- a/mix.lock
+++ b/mix.lock
@@ -2,4 +2,5 @@
   "esqlite": {:hex, :esqlite, "0.1.0"},
   "ex_doc": {:hex, :ex_doc, "0.7.2"},
   "inch_ex": {:hex, :inch_ex, "0.2.4"},
+  "pipe": {:hex, :pipe, "0.0.1"},
   "poison": {:hex, :poison, "1.4.0"}}


### PR DESCRIPTION
I was reading through your PR tonight and I was wondering if it was possible to reorganize the `query` logic into a pipeline rather than a set of nested function calls.

I'm not really sure if this is actually an improvement on the code, but I'm curious to get your feedback.
## Things I Like
- most of the pattern matching has been pushed into function clauses rather than case statements
- query logic has been separated into its own module
- `Sqlitex.query/2` is now a very readable pipeline, easier to dive into than walking through the nested function calls that previously existed
## Things I Don't Like
- `Sqlitex.Query.bind_values/2` has to use a `case` statement to pass along the statement so we can keep it passing through the pipeline
- `Sqlitex.Query.to_rows/1` takes a single tuple with four items, instead of four arguments. Not a huge deal, but I would prefer 4 explicit arguments.
- When an error occurs, the errors gets passed through the rest of the pipeline before coming back to the user, rather than returning early and avoiding extra function calls

/cc @jazzyb 
